### PR TITLE
Fix regression of initWithContent in Repetition

### DIFF
--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -647,7 +647,7 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
      */
     initWithContent: {
         value: function (content) {
-            this.object = content;
+            this.content = content;
             return this;
         }
     },


### PR DESCRIPTION
Repetition’s initWithContent was changed by error to set object instead
of content.