### PR TITLE
Remove unnecessary comment from Range Controller

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -581,7 +581,6 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
         value: function (index, length, values) {
             var result = this.content.swap.apply(this.content, arguments);
             if (values) {
-                // TODO WTF index vs index
                 for (index = 2; index < values.length; index++) {
                     this.handleAdd(values[index]);
                 }


### PR DESCRIPTION
In the code, index is defined as a function parameter and then reused as
a variable. It seems that the commenter got confused by the reusing, but
as it is perfectly valid code I’m removing the comment.