### PR TITLE
Add stride animation to Flow after pointer cancel

### DIFF
--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -288,6 +288,27 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
         }
     },
 
+    _cancel: {
+        value: function (event) {
+            this.startTime = Date.now();
+            this.endX = this.posX = this.startX = this._translateX;
+            this.endY = this.posY = this.startY = this._translateY;
+            if (this.translateStrideX) {
+                this.startStrideXTime = null;
+                this.startStrideYTime = null;
+                this.animateMomentum = true;
+                this._animationInterval();
+            } else {
+                this.animateMomentum = false;
+            }
+            if (!this._isFirstMove) {
+                this.isMoving = false;
+                this._dispatchTranslateCancel();
+            }
+            this._releaseInterest();
+        }
+    },
+
     _translateEndTimeout: {
         value: null
     },


### PR DESCRIPTION
Flow was missing stride animations after a pointer cancel event, causing
it to stay in intermediate positions in that case. This commit fixes the
issue by allowing stride animations after the cancelation.