### PR TITLE
Fix global variable in core/mr/browser.js

### DIFF
--- a/core/mr/browser.js
+++ b/core/mr/browser.js
@@ -66,7 +66,7 @@ bootstrap("require/browser", function (require) {
         globalEval = /*this.execScript ||*/eval,
 
         emptyFactory = function () {
-        };
+        },
 
         /*jshint evil:true */
         global = globalEval('this'),


### PR DESCRIPTION
A typo semicolon instead of comma in a var declaration has been causing
two issues: a variable not declared and a variable declared as
global. As a side effect of this base href wasn't working anymore. This
commit fixes the typo and issues.