### PR TITLE
Fix Capacitor

### DIFF
--- a/core/mr/browser.js
+++ b/core/mr/browser.js
@@ -170,14 +170,12 @@ bootstrap("require/browser", function (require) {
             xhr.send(null);
         } else {
             xhr.reject(new Error("Can't XHR " + JSON.stringify(url)));
-            onerror.xhrPool.push(xhr);
             //This clears the response from memory
             xhr.abort();
             xhr.url = null;
             xhr.module = null;
         }
     }
-    onerror.xhrPool = xhrPool;
 
     function RequireRead(url, module) {
         var xhr = RequireRead.xhrPool.length && RequireRead.xhrPool.pop();


### PR DESCRIPTION
RequireRead is recycling XMLHttpRequest objects. When the request loads
it is not a problem to recycle the object, but when it errors then it
won't reopen and further request won't work. With a http/s server, this
is usually not noticeable nor a problem as most requests ends loading,
some as 404, some as 200. When used from the filesystem or a bundle
inside a webview as in Capacitor, the behaviour is different. When a
is not found the request errors, and then it becomes problematic
if tried to be reused.

In this commit I'm stopping pushing xhrs after errors in the recycling
pool and it fixes the issues